### PR TITLE
Bug missing dependencies

### DIFF
--- a/lib/bittrex/client.rb
+++ b/lib/bittrex/client.rb
@@ -1,5 +1,6 @@
 require 'faraday'
 require 'base64'
+require 'json'
 
 module Bittrex
   class Client

--- a/lib/bittrex/market.rb
+++ b/lib/bittrex/market.rb
@@ -1,3 +1,5 @@
+require 'time'
+
 module Bittrex
   class Market
     attr_reader :name, :currency, :base, :currency_name, :base_name, :minimum_trade, :active, :created_at, :raw


### PR DESCRIPTION
Adds missing requires in Client and Market. 

`require 'json'` already fixed in main repo here: https://github.com/mwerner/bittrex/pull/2

cc: @eiannone @pnicolai @mhuggins