### PR TITLE
Fix Bittrex::Wallet.all

### DIFF
--- a/lib/bittrex/wallet.rb
+++ b/lib/bittrex/wallet.rb
@@ -14,7 +14,7 @@ module Bittrex
     end
 
     def self.all
-      client.get('account/getbalances').values.map{|data| new(data) }
+      client.get('account/getbalances').map{|data| new(data) }
     end
 
     private


### PR DESCRIPTION
As noted on https://bittrex.com/home/api

The result of `getbalances` returns an Array so calling `values` throws an error. 

Removing `values` fixes things 🎉 

If you don't have an API key configured, these non-public API calls just barf, which is silly. It will be great to differentiate between private and public calls and give more useful errors. 